### PR TITLE
Fix AI service dev environment

### DIFF
--- a/llm-service/.env.dev
+++ b/llm-service/.env.dev
@@ -1,5 +1,5 @@
 # MySQL Connection (Backend database - read only)
-MYSQL_HOST=localhost
+MYSQL_HOST=fastapi_mysql_db
 MYSQL_USER=testuser
 MYSQL_PASSWORD=testpass
 MYSQL_DATABASE=testdb

--- a/llm-service/Dockerfile
+++ b/llm-service/Dockerfile
@@ -35,6 +35,7 @@ WORKDIR /app
 
 # Copy Python packages từ builder
 COPY --from=builder /root/.local /home/appuser/.local
+COPY --from=builder /root/.local /root/.local
 
 # Copy application code
 COPY ./app ./app
@@ -47,7 +48,7 @@ RUN mkdir -p /app/data/models /app/data/chroma_db && \
 USER appuser
 
 # Update PATH
-ENV PATH=/home/appuser/.local/bin:$PATH
+ENV PATH=/home/appuser/.local/bin:/root/.local/bin:$PATH
 
 # Expose port
 EXPOSE 8001

--- a/llm-service/app/core/config.py
+++ b/llm-service/app/core/config.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
     """
     
     # MySQL Configuration (kết nối đến backend database)
-    mysql_host: str = Field(default="backend-db", env="MYSQL_HOST")
+    mysql_host: str = Field(default="fastapi_mysql_db", env="MYSQL_HOST")
     mysql_user: str = Field(default="testuser", env="MYSQL_USER")
     mysql_password: str = Field(default="testpass", env="MYSQL_PASSWORD")
     mysql_database: str = Field(default="testdb", env="MYSQL_DATABASE")


### PR DESCRIPTION
## Summary
- update default MySQL host to use backend DB container
- tweak Dockerfile so packages are available for root user
- update example `.env.dev` for llm-service

## Testing
- `./llm-service/run-dev.sh` *(fails: Docker chưa được cài đặt)*

------
https://chatgpt.com/codex/tasks/task_e_688a531037b88329bb0de04ec4ad544b