### PR TITLE
Fix llm service node parser and backend PYTHONPATH

### DIFF
--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -3,5 +3,6 @@ services:
     command: ["uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
     environment:
       - ENV=dev
+      - PYTHONPATH=/app
     volumes:
       - ./app:/app  # Mount code để hot reload

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - PYTHONPATH=/app
     ports:
       - "8000:8000"
     volumes:

--- a/llm-service/app/services/document_processor.py
+++ b/llm-service/app/services/document_processor.py
@@ -29,21 +29,23 @@ class DocumentProcessor:
     """
     
     def __init__(self):
-        # Text splitter cho việc chia document thành chunks
-        self.text_splitter = SentenceSplitter(
+        # Node parser sử dụng cho việc chia nhỏ văn bản thành các chunk
+        # Trong phiên bản mới của ``llama_index`` lớp ``SimpleNodeParser`` đã
+        # được thay thế bởi ``SentenceSplitter``. Do đó chúng ta khởi tạo trực
+        # tiếp ``SentenceSplitter`` với các tham số cần thiết và dùng nó như
+        # node parser.
+        self.node_parser = SentenceSplitter(
             chunk_size=settings.chunk_size,
             chunk_overlap=settings.chunk_overlap,
             separator=" ",
             paragraph_separator="\n\n",
-            secondary_chunking_regex="[.!?]"  # Chia theo câu
-        )
-        
-        # Node parser cho LlamaIndex
-        self.node_parser = SimpleNodeParser.from_defaults(
-            text_splitter=self.text_splitter,
+            secondary_chunking_regex="[.!?]",
             include_metadata=True,
-            include_prev_next_rel=True  # Include relationships
+            include_prev_next_rel=True,
         )
+
+        # Giữ ``text_splitter`` để tương thích với các phần khác của code
+        self.text_splitter = self.node_parser
     
     async def process_document(
         self,


### PR DESCRIPTION
## Summary
- update document processor to work with new llama_index
- ensure backend containers have PYTHONPATH set to /app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a67eafbdc8329bdd3f5fd1ec52cb8